### PR TITLE
Quick check if the path in the textbox is a valid file

### DIFF
--- a/src/view/Tui.cs
+++ b/src/view/Tui.cs
@@ -7,6 +7,7 @@ namespace MusicSharp
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.IO;
     using Terminal.Gui;
 
     /// <summary>
@@ -210,9 +211,16 @@ namespace MusicSharp
 
             if (!d.Canceled)
             {
+                if (File.Exists(d.FilePath.ToString()))
+                {
                 this.player.LastFileOpened = d.FilePath.ToString();
                 this.player.OpenFile(this.player.LastFileOpened);
                 this.NowPlaying(this.player.LastFileOpened);
+                }
+                else
+                {
+                    //This is a good spot for an error message, should one be wanted/needed
+                }
             }
         }
 


### PR DESCRIPTION
Quick check for path validity before opening another function to open the file at path. Left out Error message since I didn't know how you want error messages displayed.